### PR TITLE
chore: upgrade typescript to v6

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -27,7 +27,7 @@
         "react-router": "^7.14.2",
         "react-router-bootstrap": "^0.26.3",
         "remark-gfm": "^4.0.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vite": "^7.3.2"
       },
       "devDependencies": {
@@ -9576,9 +9576,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/client/package.json
+++ b/client/package.json
@@ -30,7 +30,7 @@
     "react-router": "^7.14.2",
     "react-router-bootstrap": "^0.26.3",
     "remark-gfm": "^4.0.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^7.3.2"
   },
   "scripts": {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -17,7 +17,10 @@
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
+    "types": [
+      "node"
+    ],
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
This pull request updates the TypeScript version used in the client and makes related configuration changes to the TypeScript settings. The most important changes are summarized below:

Dependency updates:

* Upgraded the `typescript` dependency from version `5.9.3` to `6.0.3` in both `package.json` and `package-lock.json` to ensure compatibility with the latest features and improvements. [[1]](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fL33-R33) [[2]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL30-R30) [[3]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL9579-R9581)

TypeScript configuration changes:

* Changed the `moduleResolution` setting in `tsconfig.json` from `"node"` to `"bundler"` to align with modern bundler-based workflows.
* Added `"types": ["node"]` to the `tsconfig.json` to explicitly include Node.js type definitions, improving type checking and compatibility.