### PR TITLE
feat: add scheduled backups

### DIFF
--- a/.github/workflows/cd-main.yml
+++ b/.github/workflows/cd-main.yml
@@ -109,6 +109,8 @@ jobs:
             -var="db_name=${{ secrets.DB_NAME }}" \
             -var="security_key=${{ secrets.JWT_SECURITY_KEY }}" \
             -var="mailgun_apikey=${{ secrets.MAILGUN_API_KEY }}" \
+            -var="r2_access_key=${{ secrets.R2_ACCESS_KEY_ID }}" \
+            -var="r2_secret_key=${{ secrets.R2_SECRET_ACCESS_KEY }}" \
             -var="backend_image=${{ steps.deploy-vars.outputs.backend_image }}" \
             -var="frontend_image=${{ steps.deploy-vars.outputs.frontend_image }}"
           terraform show -json tfplan > tfplan.json

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "3.1.0"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:oodIAuFMikXNmEtil5MQgP4dfSctUBYQiGJfjbsF3NY=",
+    "zh:0215c5c60be62028c09a2f22458e89cda3ef5830a632299f1d401eb3538874b0",
+    "zh:09ebb9f442431e278a310a9423f32caf467cb4b3cad3fe59573ca71fa7b14e20",
+    "zh:0c4e5912f83bb35846ae0a9ae54fc320706ee61894cd21cc6b4181b1c5a2fa5c",
+    "zh:1678c982853ad461e65ccb5e79d585e13ed109dd47dab2a66d3a7a304faeef65",
+    "zh:1c050a5c15e330457a9c18caacf61a923c59d663e13f2962e4b32f04fef523a0",
+    "zh:2c55bcec83be58ec132c7cb0a1ac644758b800d794fdc636d53a0eada0358a3a",
+    "zh:a062bb0aa316c08d8460c66a5d68da71da40de5d3bc3b31abcf3a1a9a19650f1",
+    "zh:a26fdea0afaa9b247c73c0b42843ca51ba7db0ac2571f9d3d50dcabd20ca1b98",
+    "zh:c872c9385a78d502bf5823d61cd3bb0f9a0585030e025eb12585c83451beeaa1",
+    "zh:f180879af931182beee4c8c0d9dab62b81d86f17ddcbe3786ef4c7cec9163a4e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f70f5789264069e0eef06f9b5d5fde955ef7206f7d446d1ce51a4c37a3f3e02f",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -48,6 +48,26 @@ variable "mailgun_apikey" {
   sensitive = true
 }
 
+variable "r2_access_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "r2_secret_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "r2_bucket_name" {
+  type    = string
+  default = "tasknote-backups"
+}
+
+variable "r2_endpoint" {
+  type    = string
+  default = "https://d17eb09b6bce2f90e16e800bb2a6baf9.r2.cloudflarestorage.com"
+}
+
 variable "cors_allowed_origins" {
   type    = string
   default = "https://tasknote.darkroasted.vps-kinghost.net"
@@ -368,3 +388,120 @@ resource "kubernetes_ingress_v1" "tasknote_ingress" {
     }
   }
 }
+
+resource "kubernetes_secret_v1" "r2_backup_secrets" {
+  metadata {
+    name      = "r2-backup-secrets"
+    namespace = kubernetes_namespace_v1.tasknote.metadata[0].name
+  }
+
+  data = {
+    access_key = var.r2_access_key
+    secret_key = var.r2_secret_key
+  }
+}
+
+resource "kubernetes_cron_job_v1" "polpa_gestao_db_backup" {
+  metadata {
+    name      = "polpa-gestao-db-backup"
+    namespace = kubernetes_namespace_v1.tasknote.metadata[0].name
+  }
+  spec {
+    schedule = "0 0,12 * * *"
+    job_template {
+      metadata {
+        labels = {
+          app = "taknote-db-backup"
+        }
+      }
+      spec {
+        template {
+          metadata {
+            labels = {
+              app = "tasknote-db-backup"
+            }
+          }
+          spec {
+            container {
+              name    = "backup"
+              image   = "postgres:15.8-alpine"
+              command = ["/bin/sh", "-c"]
+              args = [
+                <<-EOT
+                apk add --no-cache aws-cli
+                export PGPASSWORD=$POSTGRES_PASSWORD
+                FILENAME="backup-$(date +%Y%m%d%H%M%S).sql.gz"
+                echo "Starting backup of $POSTGRES_DB to $FILENAME..."
+                pg_dump -h $DB_HOST -U $POSTGRES_USER $POSTGRES_DB | gzip > /tmp/$FILENAME
+                echo "Uploading to R2..."
+                AWS_ACCESS_KEY_ID=$R2_ACCESS_KEY AWS_SECRET_ACCESS_KEY=$R2_SECRET_KEY \
+                aws s3 cp /tmp/$FILENAME s3://$R2_BUCKET/ --endpoint-url $R2_ENDPOINT
+                echo "Backup completed successfully."
+                EOT
+              ]
+              env {
+                name  = "DB_HOST"
+                value = "tasknote-db-svc"
+              }
+              env {
+                name = "POSTGRES_USER"
+                value_from {
+                  secret_key_ref {
+                    name = kubernetes_secret_v1.tasknote_secrets.metadata[0].name
+                    key  = "postgres_user"
+                  }
+                }
+              }
+              env {
+                name = "POSTGRES_PASSWORD"
+                value_from {
+                  secret_key_ref {
+                    name = kubernetes_secret_v1.tasknote_secrets.metadata[0].name
+                    key  = "postgres_password"
+                  }
+                }
+              }
+              env {
+                name = "POSTGRES_DB"
+                value_from {
+                  secret_key_ref {
+                    name = kubernetes_secret_v1.tasknote_secrets.metadata[0].name
+                    key  = "postgres_db"
+                  }
+                }
+              }
+              env {
+                name = "R2_ACCESS_KEY"
+                value_from {
+                  secret_key_ref {
+                    name = kubernetes_secret_v1.r2_backup_secrets.metadata[0].name
+                    key  = "access_key"
+                  }
+                }
+              }
+              env {
+                name = "R2_SECRET_KEY"
+                value_from {
+                  secret_key_ref {
+                    name = kubernetes_secret_v1.r2_backup_secrets.metadata[0].name
+                    key  = "secret_key"
+                  }
+                }
+              }
+              env {
+                name  = "R2_BUCKET"
+                value = var.r2_bucket_name
+              }
+              env {
+                name  = "R2_ENDPOINT"
+                value = var.r2_endpoint
+              }
+            }
+            restart_policy = "OnFailure"
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -401,9 +401,9 @@ resource "kubernetes_secret_v1" "r2_backup_secrets" {
   }
 }
 
-resource "kubernetes_cron_job_v1" "polpa_gestao_db_backup" {
+resource "kubernetes_cron_job_v1" "tasknote_db_backup" {
   metadata {
-    name      = "polpa-gestao-db-backup"
+    name      = "tasknote-db-backup"
     namespace = kubernetes_namespace_v1.tasknote.metadata[0].name
   }
   spec {


### PR DESCRIPTION
This pull request introduces a new automated database backup process to Cloudflare R2 storage for the Kubernetes deployment, along with supporting infrastructure changes. It adds new secrets, variables, and a scheduled Kubernetes job to perform and upload database backups, and updates the Terraform provider lock file.

**Infrastructure: Automated Database Backups to R2**

* Added a new `kubernetes_cron_job_v1` resource in `terraform/main.tf` to schedule and run database backups twice daily, using a `postgres:15.8-alpine` container that uploads compressed dumps to R2 using the AWS CLI.
* Created a new Kubernetes secret (`kubernetes_secret_v1.r2_backup_secrets`) to securely provide R2 access keys to the backup job.

**Configuration: Secrets and Variables**

* Introduced new sensitive Terraform variables for R2 access key, secret key, bucket name, and endpoint in `terraform/main.tf`.
* Updated the GitHub Actions deployment workflow (`.github/workflows/cd-main.yml`) to pass R2 credentials as Terraform variables during deployment.

**Dependency Management**

* Added a new lock entry for the `kubernetes` Terraform provider in `terraform/.terraform.lock.hcl` to ensure consistent provider versions.