### PR TITLE
feat: update auth provider to not refresh token every 2 minutes

### DIFF
--- a/client/src/context/AuthProvider.tsx
+++ b/client/src/context/AuthProvider.tsx
@@ -16,7 +16,6 @@ const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }: Pro
   const [loading, setLoading] = useState<boolean>(true);
   const [user, setUser] = useState<UserResponse | undefined>();
   const [isAdmin, setIsAdmin] = useState<boolean>(false);
-  const [intervalInstance, setIntervalInstance] = useState<NodeJS.Timeout | null>(null);
 
   const fetchCurrentSession = async (pathname: string): Promise<SigninResponse | undefined> => {
     const token = localStorage.getItem(API_TOKEN);
@@ -115,53 +114,16 @@ const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }: Pro
     setSigned(false);
     setUser(undefined);
     setIsAdmin(false);
-    if (intervalInstance) {
-      clearInterval(intervalInstance);
-      setIntervalInstance(null);
-    }
     localStorage.removeItem(API_TOKEN);
     localStorage.removeItem(REDIRECT_PATH);
     localStorage.removeItem(USER_DATA);
   };
-
-  const refreshTokenPvt = async (): Promise<void> => {
-    const bearerToken: SigninResponse | undefined = await fetchCurrentSession('/');
-    if (bearerToken) {
-      updateUserSession(null, bearerToken.token);
-    }
-    return Promise.resolve();
-  };
-
-  // 2 minutes
-  const second = 1000;
-  const minute = second * 60;
-  const REFRESH_TIMER = minute * 2;
 
   useEffect(() => {
     checkCurrentAuthUser(window.location.pathname)
       .catch(e => console.error(e))
       .finally(() => setLoading(false));
   }, []);
-
-  useEffect(() => {
-    if (signed && intervalInstance == null) {
-      const instance = setInterval(() => {
-        refreshTokenPvt()
-          .then(() => {
-            console.debug('User session successfully refreshed!');
-          })
-          .catch(e => console.error(e));
-      }, REFRESH_TIMER);
-
-      setIntervalInstance(instance);
-    }
-
-    return () => {
-      if (intervalInstance) {
-        clearInterval(intervalInstance);
-      }
-    };
-  }, [signed, intervalInstance]);
 
   const updateUser = (userUpdated: UserResponse): void => {
     setUser(userUpdated);


### PR DESCRIPTION
This pull request removes the logic for periodically refreshing the user session token in the `AuthProvider` component. The code responsible for setting up and clearing an interval to refresh the token every two minutes has been deleted, simplifying the authentication context.

Authentication session management:

* Removed the `intervalInstance` state and related logic for setting up a periodic token refresh using `setInterval`, including the `refreshTokenPvt` function and the associated `useEffect` hook. Now, the user session will no longer be automatically refreshed at regular intervals. [[1]](diffhunk://#diff-baa47e19d282c89c99b4c2116a7f87a54a3ea115cb61bbdad0771280c33d6140L19) [[2]](diffhunk://#diff-baa47e19d282c89c99b4c2116a7f87a54a3ea115cb61bbdad0771280c33d6140L118-L165)
* Cleaned up the logout process by removing interval cleanup logic, as it is no longer needed.