### PR TITLE
ci: update cd-main to deploy to GCP using WIF

### DIFF
--- a/.github/workflows/cd-main.yml
+++ b/.github/workflows/cd-main.yml
@@ -25,28 +25,23 @@ jobs:
       no_changes: ${{ steps.check-changes.outputs.no_changes }}
     permissions:
       contents: read
+      id-token: write # Required for GCP WIF
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: '${{ secrets.GCP_PROJECT_ID }}'
+          workload_identity_provider: '${{ secrets.GCP_WIF_PROVIDER }}'
+          service_account: '${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}'
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
-
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@v4
-
-      - name: Setup Kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.KUBECONFIG_DATA }}" | base64 -d > ~/.kube/config
-          chmod 600 ~/.kube/config
-
-      - name: Validate cluster access
-        run: |
-          kubectl cluster-info
-          kubectl get namespace tasknote
 
       - name: Determine deployment values
         id: deploy-vars
@@ -82,35 +77,34 @@ jobs:
           echo "frontend_image=$frontend_image" >> "$GITHUB_OUTPUT"
 
       - name: Terraform Fmt -check -diff
-        working-directory: terraform
+        working-directory: terraform-gcp
         run: terraform fmt -check -diff
 
       - name: Terraform Init
-        working-directory: terraform
+        working-directory: terraform-gcp
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: terraform init -input=false
 
       - name: Terraform Validate
-        working-directory: terraform
+        working-directory: terraform-gcp
         run: terraform validate
 
       - name: Terraform Plan
         id: check-changes
-        working-directory: terraform
+        working-directory: terraform-gcp
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: |
-          timeout 1m terraform plan -input=false -out=tfplan \
+          terraform plan -input=false -out=tfplan \
+            -var="project_id=${{ secrets.GCP_PROJECT_ID }}" \
             -var="db_user=${{ secrets.DB_USER }}" \
             -var="db_password=${{ secrets.DB_PASSWORD }}" \
             -var="db_name=${{ secrets.DB_NAME }}" \
             -var="security_key=${{ secrets.JWT_SECURITY_KEY }}" \
             -var="mailgun_apikey=${{ secrets.MAILGUN_API_KEY }}" \
-            -var="r2_access_key=${{ secrets.R2_ACCESS_KEY_ID }}" \
-            -var="r2_secret_key=${{ secrets.R2_SECRET_ACCESS_KEY }}" \
             -var="backend_image=${{ steps.deploy-vars.outputs.backend_image }}" \
             -var="frontend_image=${{ steps.deploy-vars.outputs.frontend_image }}"
           terraform show -json tfplan > tfplan.json
@@ -127,7 +121,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: tfplan
-          path: terraform/tfplan
+          path: terraform-gcp/tfplan
 
   terraform-apply:
     runs-on: ubuntu-latest
@@ -137,12 +131,21 @@ jobs:
       && needs.terraform-plan.outputs.no_changes == 'false'
     environment:
       name: production
-      url: https://tasknote.darkroasted.vps-kinghost.net
+      url: https://tasknote.cc
     permissions:
       contents: read
+      id-token: write # Required for GCP WIF
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: '${{ secrets.GCP_PROJECT_ID }}'
+          workload_identity_provider: '${{ secrets.GCP_WIF_PROVIDER }}'
+          service_account: '${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}'
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -151,24 +154,18 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: tfplan
-          path: terraform
-
-      - name: Setup Kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.KUBECONFIG_DATA }}" | base64 -d > ~/.kube/config
-          chmod 600 ~/.kube/config
+          path: terraform-gcp
 
       - name: Terraform Init
-        working-directory: terraform
+        working-directory: terraform-gcp
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: terraform init -input=false
 
       - name: Terraform Apply
-        working-directory: terraform
+        working-directory: terraform-gcp
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-        run: timeout 1m terraform apply tfplan
+        run: terraform apply tfplan

--- a/terraform/k3s-redirect.yaml
+++ b/terraform/k3s-redirect.yaml
@@ -1,0 +1,42 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: tasknote-external-redirect
+  namespace: default
+spec:
+  redirectRegex:
+    regex: "^https?://tasknote.darkroasted.vps-kinghost.net/(.*)"
+    replacement: "https://tasknote.cc/${1}"
+    permanent: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redirect-placeholder
+  namespace: default
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tasknote-redirect-ingress
+  namespace: default
+  annotations:
+    # Note the change to the provider name here as well
+    traefik.ingress.kubernetes.io/router.middlewares: default-tasknote-external-redirect@kubernetescrd
+spec:
+  rules:
+  - host: tasknote.darkroasted.vps-kinghost.net
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: redirect-placeholder
+            port:
+              number: 80


### PR DESCRIPTION
This pull request updates the deployment pipeline to migrate from a generic or Azure-based Kubernetes and Terraform setup to a Google Cloud Platform (GCP) workflow using Workload Identity Federation (WIF). It also introduces a Kubernetes redirect configuration to ensure traffic to the old domain is redirected to the new one. The changes streamline infrastructure management and improve security and maintainability.

**CI/CD Pipeline Migration to GCP:**
- Updated the GitHub Actions workflow (`cd-main.yml`) to authenticate with GCP using Workload Identity Federation, replacing previous Azure and manual kubeconfig steps. [[1]](diffhunk://#diff-db8348421fce2aa801fab581bf762b16209ccc8a424dd3eee7881ab829870027R28-L50) [[2]](diffhunk://#diff-db8348421fce2aa801fab581bf762b16209ccc8a424dd3eee7881ab829870027L140-R148)
- Changed Terraform working directory references from `terraform` to `terraform-gcp` throughout the workflow for plan, apply, and artifact steps. [[1]](diffhunk://#diff-db8348421fce2aa801fab581bf762b16209ccc8a424dd3eee7881ab829870027L85-L113) [[2]](diffhunk://#diff-db8348421fce2aa801fab581bf762b16209ccc8a424dd3eee7881ab829870027L130-R124) [[3]](diffhunk://#diff-db8348421fce2aa801fab581bf762b16209ccc8a424dd3eee7881ab829870027L154-R171)
- Updated the deployment environment URL from the old domain to `https://tasknote.cc`.
- Removed all Azure and manual Kubernetes configuration steps from the workflow, relying solely on GCP authentication and management. [[1]](diffhunk://#diff-db8348421fce2aa801fab581bf762b16209ccc8a424dd3eee7881ab829870027R28-L50) [[2]](diffhunk://#diff-db8348421fce2aa801fab581bf762b16209ccc8a424dd3eee7881ab829870027L154-R171)

**Domain Redirection:**
- Added a new Kubernetes manifest (`terraform/k3s-redirect.yaml`) that configures Traefik middleware and ingress to redirect all traffic from `tasknote.darkroasted.vps-kinghost.net` to `https://tasknote.cc`. This ensures a seamless transition for users accessing the old domain.