### PR TITLE
feat: update to new domain

### DIFF
--- a/.github/workflows/ci-pr-backend.yml
+++ b/.github/workflows/ci-pr-backend.yml
@@ -10,6 +10,7 @@ on:
       - 'server/**/*.java'
       - 'server/**/*.xml'
       - 'server/pom.xml'
+      - 'server/**/*.yml'
       - '.github/workflows/server-ci.yml'
 
 jobs:

--- a/mailgun-templates/email_changed.html
+++ b/mailgun-templates/email_changed.html
@@ -157,14 +157,14 @@
 				<p>If you made this change, no further action is needed.</p>
 				<p>
 				  If you did not make this change, secure your account immediately and contact
-				  <a class="link" href="mailto:ricardompcampos@gmail.com">ricardompcampos@gmail.com</a>.
+				  <a class="link" href="mailto:support@tasknote.cc">support@tasknote.cc</a>.
 				</p>
 			  </td>
 			</tr>
 			<tr>
 			  <td class="footer">
 				This is an automatic message from Tasknote, please do not reply.<br />
-				Need help? Contact <a class="link" href="mailto:ricardompcampos@gmail.com">ricardompcampos@gmail.com</a>.
+				Need help? Contact <a class="link" href="mailto:support@tasknote.cc">support@tasknote.cc</a>.
 			  </td>
 			</tr>
 		  </table>

--- a/mailgun-templates/password_change_confirmation.html
+++ b/mailgun-templates/password_change_confirmation.html
@@ -125,7 +125,7 @@
 				<p class="notice">
 				  If this was you, no action is required. If this was not you, secure your account
 				  right away and contact
-				  <a class="link" href="mailto:ricardompcampos@gmail.com">ricardompcampos@gmail.com</a>.
+				  <a class="link" href="mailto:support@tasknote.cc">support@tasknote.cc</a>.
 				</p>
 
 				<p>Thank you for helping keep your account safe.</p>
@@ -134,7 +134,7 @@
 			<tr>
 			  <td class="footer">
 				This is an automatic message from Tasknote, please do not reply.<br />
-				Need help? Contact <a class="link" href="mailto:ricardompcampos@gmail.com">ricardompcampos@gmail.com</a>.
+				Need help? Contact <a class="link" href="mailto:support@tasknote.cc">support@tasknote.cc</a>.
 			  </td>
 			</tr>
 		  </table>

--- a/mailgun-templates/password_reset.html
+++ b/mailgun-templates/password_reset.html
@@ -167,7 +167,7 @@
 			<tr>
 			  <td class="footer">
 				This is an automatic message from Tasknote, please do not reply.<br />
-				Need help? Contact <a class="link" href="mailto:ricardompcampos@gmail.com">ricardompcampos@gmail.com</a>.
+				Need help? Contact <a class="link" href="mailto:support@tasknote.cc">support@tasknote.cc</a>.
 			  </td>
 			</tr>
 		  </table>

--- a/mailgun-templates/sign_up_confirmation.html
+++ b/mailgun-templates/sign_up_confirmation.html
@@ -157,7 +157,7 @@
 			<tr>
 			  <td class="footer">
 				This is an automatic message from Tasknote, please do not reply.<br />
-				Need help? Contact <a class="link" href="mailto:ricardompcampos@gmail.com">ricardompcampos@gmail.com</a>.
+				Need help? Contact <a class="link" href="mailto:support@tasknote.cc">support@tasknote.cc</a>.
 			  </td>
 			</tr>
 		  </table>

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -13,8 +13,8 @@ logging:
 
 mailgun:
   api-key: ${MAILGUN_APIKEY:abc123456}
-  domain: tasknote.darkroasted.vps-kinghost.net
-  sender-email: no-reply@tasknote.darkroasted.vps-kinghost.net
+  domain: tasknote.cc
+  sender-email: no-reply@tasknote.cc
 
 server:
   port: 8585


### PR DESCRIPTION
This pull request updates email templates and configuration to standardize the support contact information and sender domain for Tasknote. The main changes are to replace the previous personal email and domain with the official Tasknote support email and domain.

**Email template updates:**

* Updated all references to the support email address in the following templates to use `support@tasknote.cc` instead of the previous personal email address: `email_changed.html`, `password_change_confirmation.html`, `password_reset.html`, and `sign_up_confirmation.html`. [[1]](diffhunk://#diff-0633122814509a704e4774854aacf679438a7af4c8dcd81acbca9740a7863b7bL160-R167) [[2]](diffhunk://#diff-5b36d289c587b0aa65a2f3ef698cacc651c3c0cac063683e8cc0b647085da1eeL128-R128) [[3]](diffhunk://#diff-5b36d289c587b0aa65a2f3ef698cacc651c3c0cac063683e8cc0b647085da1eeL137-R137) [[4]](diffhunk://#diff-a29af7c14b4241b7d905f9e0022d1949190535d704f8a5888dd66b6ef98c74b3L170-R170) [[5]](diffhunk://#diff-7639883d2a50c58dad0298eef22ded40379a5dfb8816f7d23229cc184c4b28d6L160-R160)

**Configuration changes:**

* Changed the Mailgun configuration in `application.yml` to use the `tasknote.cc` domain and `no-reply@tasknote.cc` as the sender email.