### PR TITLE
fix: add new domain allowed

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -70,7 +70,7 @@ variable "r2_endpoint" {
 
 variable "cors_allowed_origins" {
   type    = string
-  default = "https://tasknote.darkroasted.vps-kinghost.net"
+  default = "https://tasknote.darkroasted.vps-kinghost.net,https://tasknote.cc,https://www.tasknote.cc"
 }
 
 variable "root_log_level" {


### PR DESCRIPTION
This pull request makes a small update to the `terraform/main.tf` configuration. The change expands the allowed CORS origins to include two additional domains, improving support for multiple frontends.

- Expanded the default value of the `cors_allowed_origins` variable to allow requests from `https://tasknote.cc` and `https://www.tasknote.cc` in addition to the original domain.